### PR TITLE
Fix missing space in macro definition

### DIFF
--- a/ArxAppWiz/Templates/1033/StdAfx.h
+++ b/ArxAppWiz/Templates/1033/StdAfx.h
@@ -25,7 +25,7 @@
 //-      but are changed infrequently
 //-----------------------------------------------------------------------------
 #pragma once
-#define[!output UPPER_CASE_PROJECT_NAME] _MODULE
+#define [!output UPPER_CASE_PROJECT_NAME] _MODULE
 
 /*
 #ifndef _ALLOW_RTCc_IN_STL


### PR DESCRIPTION
This PR fixes a bug in the template where a missing space in a #define macro causes a compile-time error.

Original:
#define[!output UPPER_CASE_PROJECT_NAME] _MODULE

Fixed:
#define [!output UPPER_CASE_PROJECT_NAME] _MODULE

This ensures the generated code is valid and compiles correctly.
