### PR TITLE
Fix Create signature and parameter types to match CAcUiDockControlBar…

### DIFF
--- a/ArxWizMFCSupport/Templates/1033/DockControlBar.cpp
+++ b/ArxWizMFCSupport/Templates/1033/DockControlBar.cpp
@@ -74,9 +74,8 @@ static CLSID cls[!output CLASS_NAME] = {0xeab78c04, 0x2194, 0x47ad, {0xa4, 0xf2,
 #endif
 
 //-----------------------------------------------------------------------------
-BOOL [!output CLASS_NAME]::Create (CWnd *pParent, LPCSTR lpszTitle) {
-	CString strWndClass ;
-	strWndClass =AfxRegisterWndClass (CS_DBLCLKS, LoadCursor (NULL, IDC_ARROW)) ;
+BOOL [!output CLASS_NAME]::Create (CWnd *pParent, LPCTSTR lpszTitle) {
+	LPCTSTR strWndClass = AfxRegisterWndClass (CS_DBLCLKS, LoadCursor (NULL, IDC_ARROW)) ;
 	CRect rect (0, 0, 250, 200) ;
 	if (![!output BASE_CLASS]::Create (
 			strWndClass, lpszTitle, WS_VISIBLE | WS_CHILD | WS_CLIPCHILDREN,

--- a/ArxWizMFCSupport/Templates/1033/DockControlBar.h
+++ b/ArxWizMFCSupport/Templates/1033/DockControlBar.h
@@ -45,7 +45,7 @@ public:
 	virtual ~[!output CLASS_NAME] ();
 
 protected:
-	virtual BOOL Create (CWnd *pParent, LPCSTR lpszTitle) ;
+	virtual BOOL Create (CWnd *pParent, LPCTSTR lpszTitle) ;
 	virtual void SizeChanged (CRect *lpRect, BOOL bFloating, int flags) ;
 
 	afx_msg int OnCreate (LPCREATESTRUCT lpCreateStruct) ;


### PR DESCRIPTION
### Issue  
The original `Create` function generated by the ObjectARX wizard uses an incompatible parameter type for the first argument of both `CAcUiDockControlBar::Create` and `CAdUiDockControlBar::Create`.  
The wizard code passes a `CString` for the window class name, but these functions expect an `LPCTSTR` (or a compatible C-style string type).

This mismatch causes compilation errors such as:  
`"CAcUiDockControlBar::Create": no overloaded function takes these arguments.`

### Cause  
The parameter mismatch occurs because `CString` is not implicitly convertible to `LPCTSTR` in this context, especially in Unicode builds where proper type matching is strict.

### Fix  
- Changed the `Create` function signature to use `LPCTSTR` for the window class name parameter.  
- Used the return value of `AfxRegisterWndClass` directly as an `LPCTSTR` instead of wrapping it in a `CString`.  
- Updated usages to ensure both `CAcUiDockControlBar::Create` and `CAdUiDockControlBar::Create` are called with correct types.

### Result  
The project now compiles successfully, and the `Create` function works as expected with both `CAcUiDockControlBar` and `CAdUiDockControlBar`.
