### PR TITLE
Correct macro definition without altering original functionality

### DIFF
--- a/ArxAppWiz/Templates/1033/StdAfx.h
+++ b/ArxAppWiz/Templates/1033/StdAfx.h
@@ -25,7 +25,7 @@
 //-      but are changed infrequently
 //-----------------------------------------------------------------------------
 #pragma once
-#define [!output UPPER_CASE_PROJECT_NAME] _MODULE
+#define [!output UPPER_CASE_PROJECT_NAME]_MODULE
 
 /*
 #ifndef _ALLOW_RTCc_IN_STL


### PR DESCRIPTION
This PR fixes an issue introduced by my previous request.

The earlier PR only intended to resolve a compile-time error, but the change unintentionally altered the original behavior of the macro definition. This PR restores the intended functionality and applies the correct fix by changing:

From:
    #define [!output UPPER_CASE_PROJECT_NAME] _MODULE

To:
    #define [!output UPPER_CASE_PROJECT_NAME]_MODULE

This ensures the macro name is generated correctly without modifying the logic of the original code.
